### PR TITLE
Changed Calendar to MyCalendar 

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ In xaml:
     x:Name="mainWindow"
     ...>
 
-<calendar:CalendarMonth x:Name="Calendar" Events="{Binding ElementName=mainWindow, Path=Events}" />
+<calendar:CalendarMonth x:Name="MyCalendar" Events="{Binding ElementName=mainWindow, Path=Events}" />
 ```
 
 In code behind to display events (optionally): 
@@ -32,7 +32,7 @@ In code behind to display events (optionally):
                 OnPropertyChanged(() => Events);
 
                 // redraw days with events when Events property changes
-                Calendar.DrawDays();
+                MyCalendar.DrawDays();
             }
         }
     }

--- a/WPF.EventCalendar.Example/MainWindow.xaml
+++ b/WPF.EventCalendar.Example/MainWindow.xaml
@@ -11,6 +11,6 @@
     Height="800"
     mc:Ignorable="d">
     <Grid>
-        <calendar:CalendarMonth x:Name="Calendar" Events="{Binding ElementName=mainWindow, Path=Events}" />
+        <calendar:CalendarMonth x:Name="MyCalendar" Events="{Binding ElementName=mainWindow, Path=Events}" />
     </Grid>
 </Window>

--- a/WPF.EventCalendar.Example/MainWindow.xaml.cs
+++ b/WPF.EventCalendar.Example/MainWindow.xaml.cs
@@ -35,7 +35,7 @@ namespace WPF.EventCalendar.Example
                     OnPropertyChanged(() => Events);
 
                     // redraw days with events when Events property changes
-                    Calendar.DrawDays();
+                    MyCalendar.DrawDays();
                 }
             }
         }


### PR DESCRIPTION
I changed the name of the calendar control from Calendar to MyCalendar because Calendar is a existing control name so MyCalendar fixes the intellisense giving an error.   